### PR TITLE
Replace Toasts with proper error handling

### DIFF
--- a/android/app/src/main/kotlin/pl/kwasow/data/types/TabItem.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/data/types/TabItem.kt
@@ -12,9 +12,9 @@ data class TabItem(
     val view: @Composable () -> Unit,
 ) {
     companion object {
-        fun getWishlistTabs(user: User?): List<TabItem> {
+        fun getWishlistTabs(user: User?): List<TabItem>? {
             if (user == null) {
-                return emptyList()
+                return null
             }
 
             val partner = user.partner

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/music/AlbumDetailsView.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/music/AlbumDetailsView.kt
@@ -1,7 +1,5 @@
 package pl.kwasow.ui.screens.modules.music
 
-import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,12 +10,10 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -80,16 +76,17 @@ private fun AlbumNotFound(uuid: String) {
     ) { paddingValues ->
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .padding(16.dp)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(16.dp),
         ) {
             SelectionContainer {
                 Text(
                     stringResource(id = R.string.module_music_unknown_album_uuid, uuid),
                     textAlign = TextAlign.Center,
-                    fontStyle = FontStyle.Italic
+                    fontStyle = FontStyle.Italic,
                 )
             }
         }

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/music/AlbumDetailsView.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/music/AlbumDetailsView.kt
@@ -3,16 +3,24 @@ package pl.kwasow.ui.screens.modules.music
 import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
 import pl.kwasow.R
@@ -26,9 +34,12 @@ fun AlbumDetailsView(albumUuid: String) {
     val viewModel = koinViewModel<MusicModuleViewModel>()
     val navigation = LocalFlamingoNavigation.current
 
-    val album =
-        viewModel.getAlbumByUuid(albumUuid)
-            ?: return albumNotFound(navigation.navigateBack, LocalContext.current)
+    val album = viewModel.getAlbumByUuid(albumUuid)
+
+    if (album == null) {
+        AlbumNotFound(uuid = albumUuid)
+        return
+    }
 
     Scaffold(
         topBar = {
@@ -54,10 +65,33 @@ fun AlbumDetailsView(albumUuid: String) {
 }
 
 // ====== Private composables
-private fun albumNotFound(
-    onBackPressed: () -> Unit,
-    context: Context,
-) {
-    Toast.makeText(context, R.string.something_went_wrong, Toast.LENGTH_LONG).show()
-    onBackPressed()
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlbumNotFound(uuid: String) {
+    val navigation = LocalFlamingoNavigation.current
+
+    Scaffold(
+        topBar = {
+            FlamingoTopAppBar(
+                title = stringResource(R.string.error),
+                onBackPressed = navigation.navigateBack,
+            )
+        },
+    ) { paddingValues ->
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            SelectionContainer {
+                Text(
+                    stringResource(id = R.string.module_music_unknown_album_uuid, uuid),
+                    textAlign = TextAlign.Center,
+                    fontStyle = FontStyle.Italic
+                )
+            }
+        }
+    }
 }

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleScreen.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleScreen.kt
@@ -1,7 +1,6 @@
 package pl.kwasow.ui.screens.modules.whishlist
 
-import android.content.Context
-import android.widget.Toast
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,11 +17,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import pl.kwasow.R
@@ -59,13 +61,12 @@ fun WishlistModuleScreen() {
 @Composable
 private fun MainView(paddingValues: PaddingValues) {
     val viewModel = koinViewModel<WishlistModuleViewModel>()
-    val navigation = LocalFlamingoNavigation.current
 
     if (viewModel.tabs.isEmpty()) {
-        return errorLoadingWishlist(navigation.navigateBack, LocalContext.current)
+        ErrorLoadingUserDetails()
+    } else {
+        WishlistTabs(paddingValues = paddingValues)
     }
-
-    WishlistTabs(paddingValues = paddingValues)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -110,12 +111,20 @@ private fun WishlistTabs(paddingValues: PaddingValues) {
     }
 }
 
-private fun errorLoadingWishlist(
-    onBackPressed: () -> Unit,
-    context: Context,
-) {
-    Toast.makeText(context, R.string.something_went_wrong, Toast.LENGTH_LONG).show()
-    onBackPressed()
+@Composable
+private fun ErrorLoadingUserDetails() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            stringResource(id = R.string.error_loading_user),
+            textAlign = TextAlign.Center,
+            fontStyle = FontStyle.Italic
+        )
+    }
 }
 
 // ====== Previews

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleScreen.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import pl.kwasow.R
+import pl.kwasow.data.types.TabItem
 import pl.kwasow.ui.components.FlamingoBackgroundLight
 import pl.kwasow.ui.components.FlamingoTopAppBar
 import pl.kwasow.ui.composition.LocalFlamingoNavigation
@@ -61,19 +63,26 @@ fun WishlistModuleScreen() {
 @Composable
 private fun MainView(paddingValues: PaddingValues) {
     val viewModel = koinViewModel<WishlistModuleViewModel>()
+    val tabs = viewModel.tabs.collectAsState(null)
 
-    if (viewModel.tabs.isEmpty()) {
+    val tabsValue = tabs.value
+    if (tabsValue == null) {
         ErrorLoadingUserDetails()
     } else {
-        WishlistTabs(paddingValues = paddingValues)
+        WishlistTabs(
+            paddingValues = paddingValues,
+            tabs = tabsValue,
+        )
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun WishlistTabs(paddingValues: PaddingValues) {
-    val viewModel = koinViewModel<WishlistModuleViewModel>()
-    val pagerState = rememberPagerState(pageCount = { viewModel.tabs.size })
+private fun WishlistTabs(
+    paddingValues: PaddingValues,
+    tabs: List<TabItem>,
+) {
+    val pagerState = rememberPagerState(pageCount = { tabs.size })
     val coroutineScope = rememberCoroutineScope()
 
     Column(
@@ -83,7 +92,7 @@ private fun WishlistTabs(paddingValues: PaddingValues) {
                 .padding(paddingValues),
     ) {
         PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
-            viewModel.tabs.forEachIndexed { index, item ->
+            tabs.forEachIndexed { index, item ->
                 Tab(
                     text = { Text(text = item.title) },
                     icon = {
@@ -106,7 +115,7 @@ private fun WishlistTabs(paddingValues: PaddingValues) {
         }
 
         HorizontalPager(state = pagerState) { index ->
-            viewModel.tabs[index].view()
+            tabs[index].view()
         }
     }
 }

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleScreen.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleScreen.kt
@@ -115,14 +115,15 @@ private fun WishlistTabs(paddingValues: PaddingValues) {
 private fun ErrorLoadingUserDetails() {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
     ) {
         Text(
             stringResource(id = R.string.error_loading_user),
             textAlign = TextAlign.Center,
-            fontStyle = FontStyle.Italic
+            fontStyle = FontStyle.Italic,
         )
     }
 }

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleViewModel.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleViewModel.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import pl.kwasow.R
 import pl.kwasow.data.types.MinimalUser
@@ -23,7 +25,7 @@ class WishlistModuleViewModel(
     // ====== Fields
     private var wishlist: Map<Int, MutableList<Wish>> by mutableStateOf(emptyMap())
 
-    val tabs = TabItem.getWishlistTabs(userManager.user.value)
+    val tabs = userManager.userFlow.map { TabItem.getWishlistTabs(it) }
 
     var isWishlistLoading: Boolean by mutableStateOf(true)
         private set
@@ -39,6 +41,15 @@ class WishlistModuleViewModel(
         private set
     var wishToUpdate: Wish? by mutableStateOf(null)
         private set
+
+    // ====== Constructors
+    init {
+        viewModelScope.launch {
+            if (tabs.firstOrNull() == null) {
+                userManager.refreshUser()
+            }
+        }
+    }
 
     // ====== Public methods
     fun refreshWishlist() {

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleViewModel.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleViewModel.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import pl.kwasow.R
@@ -45,7 +45,7 @@ class WishlistModuleViewModel(
     // ====== Constructors
     init {
         viewModelScope.launch {
-            if (tabs.firstOrNull() == null) {
+            if (tabs.first() == null) {
                 userManager.refreshUser()
             }
         }

--- a/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleViewModel.kt
+++ b/android/app/src/main/kotlin/pl/kwasow/ui/screens/modules/whishlist/WishlistModuleViewModel.kt
@@ -21,11 +21,11 @@ class WishlistModuleViewModel(
     private val wishlistManager: WishlistManager,
 ) : ViewModel() {
     // ====== Fields
+    private var wishlist: Map<Int, MutableList<Wish>> by mutableStateOf(emptyMap())
+
     val tabs = TabItem.getWishlistTabs(userManager.user.value)
 
     var isWishlistLoading: Boolean by mutableStateOf(true)
-        private set
-    var wishlist: Map<Int, MutableList<Wish>> by mutableStateOf(emptyMap())
         private set
 
     var editedWish: Wish? by mutableStateOf(null)

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -32,6 +32,7 @@
     <string name="dialog_year_picker_title">Wybierz rok</string>
     <string name="something_went_wrong">Coś poszło nie tak</string>
     <string name="partner">partner</string>
+    <string name="error_loading_user">Coś poszło nie tak w trakcie wczytywania danych o użytkownikach</string>
     <!-- Module: Memories -->
     <string name="module_memories_name">Wspomnienia</string>
     <string name="module_memories_no_memories">Nie udało się załadować wspomnień</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Login -->
     <string name="login_error_no_access">Nie masz uprawnień do korzystania z tej aplikacji. Spróbuj zalogować się innym kontem.</string>
     <string name="login_error_no_connection">Nie udało się połączyć z serwerem.</string>
     <string name="login_error">Nieznany błąd logowania</string>
     <string name="login_google">Zaloguj przez Google</string>
-    <!-- Settings screen -->
     <string name="settings_label">Ustawienia</string>
     <string name="settings_play_store">Sklep Play</string>
     <string name="settings_play_store_description">Przejdź do strony aplikacji w sklepie</string>
@@ -20,7 +18,6 @@
     <string name="settings_location_sharing_description">Wysyłaj lokalizację w tle</string>
     <string name="settings_location_dialog_title">Lokalizacja</string>
     <string name="settings_location_dialog_content">Dostęp do lokalizacji w tle jest wymagany, jeśli chcesz móc sprawdzać, gdzie jest %1$s, kiedy nie korzysta z aplikacji. Aplikacja będzie też udostępniać Twoją lokalizację, nawet jeśli z niej nie korzystasz.\n\nKliknij \"OK\" aby przejść od ustawień, a następnie wybierz \"Uprawnienia\" &gt; \"Lokalizacja\" &gt; \"Zawsze zezwalaj\"</string>
-    <!-- General -->
     <string name="ok">OK</string>
     <string name="failed_loading_photo">Nie udało się załadować zdjęcia</string>
     <string name="confirm">Potwierdź</string>
@@ -33,17 +30,15 @@
     <string name="something_went_wrong">Coś poszło nie tak</string>
     <string name="partner">partner</string>
     <string name="error_loading_user">Coś poszło nie tak w trakcie wczytywania danych o użytkownikach</string>
-    <!-- Module: Memories -->
+    <string name="error">Błąd</string>
     <string name="module_memories_name">Wspomnienia</string>
     <string name="module_memories_no_memories">Nie udało się załadować wspomnień</string>
-    <!-- Widget: Memories -->
     <string name="widget_memories_no_memories">Brak wspomnień\nKocham Cię ❤️</string>
-    <!-- Module: Music -->
     <string name="module_music_name">Piosenki</string>
     <string name="module_music_no_albums">Nie udało się załadować albumów</string>
     <string name="module_music_delete_dialog_header">Usuwanie albumu</string>
     <string name="module_music_delete_dialog_text">Czy na pewno chcesz usunąć album \"%1$s\"?</string>
-    <!-- Module: Wishlist -->
+    <string name="module_music_unknown_album_uuid">Nie udało się załadować albumu o UUID \"%1$s\"</string>
     <string name="module_wishlist_name">Prezenty</string>
     <string name="module_wishlist_wish_entry_hint">Zacznij pisać…</string>
     <string name="module_wishlist_delete_dialog_header">Usuwanie prezentu</string>
@@ -51,22 +46,17 @@
     <string name="module_wishlist_add_failed">Nie udało się dodać życzenia</string>
     <string name="module_wishlist_update_failed">Nie udało się zaktualizować życzenia</string>
     <string name="module_wishlist_remove_failed">Nie udało się usunąć życzenia</string>
-    <!-- Module: Missing You -->
     <string name="module_missingyou_name">Tęsknota</string>
     <string name="module_missingyou_miss_you">Tęsknię</string>
     <string name="module_missingyou_sending_success">❤️ Tęsknota wysłana</string>
     <string name="module_missingyou_sending_failed">😢 Nie udało się wysłać tęsknoty</string>
     <string name="module_missingyou_touch_to_send">Dotknij naszyjnika, by wysłać tęsknotę</string>
-    <!-- Module: Location -->
     <string name="module_location_name">Lokalizacja</string>
     <string name="module_location_no_permission">Nie nadano uprawnień do korzystania z lokalizacji</string>
     <string name="module_location_your_location">Twoja lokalizacja</string>
-    <!-- Widget: Days Together -->
     <string name="widget_daystogether_day_together">dni razem</string>
-    <!-- Widget: Now playing -->
     <string name="widget_nowplaying_no_title">(utwór bez nazwy)</string>
     <string name="widget_nowplaying_no_artist">(artysta bez nazwy)</string>
-    <!-- Notification channels -->
     <string name="notificationChannel_memories">Wspomnienia</string>
     <string name="notificationChannel_memories_description">Tutaj będą się pojawiały powiadomienia o wspomnieniach</string>
     <string name="notification_memories_title">Wspomnienia</string>
@@ -78,7 +68,6 @@
     <string name="notification_missingyou_title1">%1$s bardzo za Tobą tęskni</string>
     <string name="notification_missingyou_title2">Ktoś się za Tobą stęsknił</string>
     <string name="notification_missingyou_title3">Brakuje mi Ciebie - %1$s</string>
-    <!-- Content description -->
     <string name="contentDescription_google_icon">Logo Google</string>
     <string name="contentDescription_karonia_logo">Logo aplikacji</string>
     <string name="contentDescription_module_icon">Moduł %1$s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="dialog_year_picker_title">Pick year</string>
     <string name="something_went_wrong">Something went wrong</string>
     <string name="partner">partner</string>
+    <string name="error_loading_user">Something went wrong while loading the user details</string>
 
     <!-- Module: Memories -->
     <string name="module_memories_name">Memories</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="something_went_wrong">Something went wrong</string>
     <string name="partner">partner</string>
     <string name="error_loading_user">Something went wrong while loading the user details</string>
+    <string name="error">Error</string>
 
     <!-- Module: Memories -->
     <string name="module_memories_name">Memories</string>
@@ -50,6 +51,7 @@
     <string name="module_music_no_albums">Failed to load albums</string>
     <string name="module_music_delete_dialog_header">Deleting album</string>
     <string name="module_music_delete_dialog_text">Are you sure you want to delete the \"%1$s\" album?</string>
+    <string name="module_music_unknown_album_uuid">Couldn\'t load album for UUID \"%1$s\"</string>
 
     <!-- Module: Wishlist -->
     <string name="module_wishlist_name">Wishlist</string>


### PR DESCRIPTION
In situations, where the Toast was used to show an error while a quick back navigation action happened, replaced with a proper error screen to avoid confusion among users.